### PR TITLE
Update utils.py for multiprocessing

### DIFF
--- a/gamma/utils.py
+++ b/gamma/utils.py
@@ -1,6 +1,7 @@
 import multiprocessing as mp
 from collections import Counter
 from datetime import datetime
+import platform
 
 import numpy as np
 import pandas as pd
@@ -109,7 +110,15 @@ def association(picks, stations, config, event_idx0=0, method="BGMM", **kwargs):
 
         # the default chunk_size is len(unique_labels)//(config["ncpu"]*4), which makes some jobs very heavy
         chunk_size = max(len(unique_labels)//(config["ncpu"]*20), 1)
-        with mp.get_context('spawn').Pool(config["ncpu"]) as p:
+        
+        # Check for OS to start a child process in multiprocessing
+        # https://superfastpython.com/multiprocessing-context-in-python/
+        if platform.system().lower() in ["darwin", "windows"]:
+            context = "spawn"
+        else:
+            context = "fork"
+        
+        with mp.get_context(context).Pool(config["ncpu"]) as p:
             results = p.starmap(
                 associate,
                 [


### PR DESCRIPTION
Fixed method to start child process in multiprocessing since 'spawn' runs into an infinite loop on Linux.