### PR TITLE
Fix: Prevent integer overflow by resetting `current_label` instead of incrementing

### DIFF
--- a/gamma/utils.py
+++ b/gamma/utils.py
@@ -113,7 +113,7 @@ def hierarchical_dbscan_clustering(data, phase_loc, phase_type, phase_weight, ve
             labels_ = np.where(labels_ == -1, -1, labels_ + current_label)
             labels[idx] = labels_
 
-            current_label += labels_.max() + 1
+            current_label = labels_.max() + 1
             keep_split = True
 
         if not keep_split:


### PR DESCRIPTION
Thank you, Dr. Zhu, for the robust association method. While using `gamma.utils.estimate_eps` and `gamma.utils.hierarchical_dbscan_clustering` functions for DBSCAN, I encountered an integer overflow warning, causing negative and duplicate labels.

To fix this, I changed `current_label += labels_.max() + 1` to `current_label = labels_.max() + 1`, preventing overflow while keeping label increments correct.